### PR TITLE
fix: js project module path error

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 	"types": "./dist/main.d.ts",
 	"files": ["dist"],
 	"scripts": {
-		"build": "tsc",
+		"build": "tsc && npx tsc-esm-fix",
 		"test": "bun test",
 		"check": "biome check"
 	},


### PR DESCRIPTION
一个朋友用到你这个库，但是在js项目里引用会报错，看了下应该是esm模块导入路径问题，修复了下。可以build后，重新publish下。